### PR TITLE
Fix -Wsign-compare warning

### DIFF
--- a/util/StringUtils.cpp
+++ b/util/StringUtils.cpp
@@ -40,7 +40,7 @@ bool stringCompare(string s1, string s2) {
 
 bool isNumber(string& s) {
 	if (s.empty()) return false;
-	for (int i = 0; i < s.size(); i++)
+	for (unsigned int i = 0; i < s.size(); i++)
 		if (! isdigit(s.at(i))) return false;
 	return true;
 }


### PR DESCRIPTION
Fix GCC's '-Wsign-compare' warning by changing flag's type from int to unsigned int.
